### PR TITLE
대시보드 편집 권한 없는 사용자의 불필요한 토스트 메시지 제거

### DIFF
--- a/aot/aot_flask/routes_dashboard.py
+++ b/aot/aot_flask/routes_dashboard.py
@@ -60,8 +60,11 @@ def inject_dictionary():
 @flask_login.login_required
 def save_dashboard_layout():
     """Save positions and sizes of widgets of a particular dashboard."""
-    if not utils_general.user_has_permission('edit_controllers'):
-        return redirect(url_for('routes_general.home'))
+    # AJAX-only endpoint: flash() here would only surface on some later,
+    # unrelated page load (the client silently follows a redirect and
+    # never sees it). Stay silent and let the client react to the 403.
+    if not utils_general.user_has_permission('edit_controllers', silent=True):
+        return jsonify({"status": "forbidden"}), 403
     data = request.get_json()
     keys = ('id', 'x', 'y', 'w', 'h')
     for index, each_widget in enumerate(data):
@@ -223,7 +226,10 @@ def get_aot_map_measurements_panel(widget_id):
 def save_dashboard_order():
     """Persist user-defined dashboard ordering and return server order."""
     try:
-        if not utils_general.user_has_permission('edit_controllers'):
+        # AJAX-only endpoint: keep the permission check silent (see
+        # save_dashboard_layout) so a denial doesn't get queued as a flash
+        # that pops up on some later, unrelated page load.
+        if not utils_general.user_has_permission('edit_controllers', silent=True):
             return jsonify({"status": "forbidden"}), 403
 
         try:
@@ -596,6 +602,8 @@ def _build_dashboard_render_context(this_dashboard, dashboard_id, form_base, for
                            input=input_dev,
                            tags=tags,
                            this_dashboard=this_dashboard,
+                           can_edit_controllers=utils_general.user_has_permission(
+                               'edit_controllers', silent=True),
                            use_unit=use_unit,
                            widgets_dash=widgets_dash,
                            widget_types_on_dashboard=widget_types_on_dashboard,
@@ -643,7 +651,10 @@ def preview_widget_options(dashboard_id, widget_id):
     so toggling options in the settings modal updates the on-dashboard widget
     without persisting anything until the user explicitly saves.
     """
-    if not utils_general.user_has_permission('edit_controllers'):
+    # AJAX-only endpoint: keep the permission check silent (see
+    # save_dashboard_layout) so a denial doesn't get queued as a flash
+    # that pops up on some later, unrelated page load.
+    if not utils_general.user_has_permission('edit_controllers', silent=True):
         return jsonify({'error': 'permission denied'}), 403
     this_dashboard = Dashboard.query.filter(
         Dashboard.unique_id == dashboard_id).first()

--- a/aot/aot_flask/static/js/app/dashboard.js
+++ b/aot/aot_flask/static/js/app/dashboard.js
@@ -87,6 +87,7 @@ const DashboardGrid = {
         // Configuration
         const cellHeight = (typeof window.AOT_GRID_CELL_HEIGHT !== 'undefined') ? window.AOT_GRID_CELL_HEIGHT : 150;
         const isLocked = (typeof window.AOT_DASHBOARD_LOCKED !== 'undefined') && window.AOT_DASHBOARD_LOCKED;
+        const canEditControllers = (typeof window.AOT_CAN_EDIT_CONTROLLERS === 'undefined') || window.AOT_CAN_EDIT_CONTROLLERS;
         
         const options = {
             cellHeight: cellHeight,
@@ -151,8 +152,13 @@ const DashboardGrid = {
             window.dispatchEvent(new Event('resize'));
         });
 
-        // If not locked, enable save and UI interactions
-        if (!isLocked) {
+        // Only enable drag/resize + autosave for viewers who can actually save
+        // a layout change. Binding this for a read-only viewer meant a passive
+        // page load or window resize could fire an unauthorized autosave POST,
+        // which surfaced as a permission-denied toast on some later, unrelated
+        // page load (see enableEditing()'s save error handler for the case
+        // where an actual edit gesture is denied).
+        if (!isLocked && canEditControllers) {
             this.enableEditing();
         }
     },
@@ -315,8 +321,18 @@ const DashboardGrid = {
                     data: payload,
                     contentType: "application/json; charset=utf-8",
                     success: () => { /* silent success */ },
-                    error: () => {
-                        window.showToast(_('layout_save_fail'), 'error');
+                    error: (jqXHR) => {
+                        // Permission was revoked mid-session (e.g. role change in
+                        // another tab): surface it right now, tied to this actual
+                        // edit gesture, instead of leaving it to appear later.
+                        // Reuses the same catalog string the server flashes for
+                        // this exact denial, so the wording matches everywhere.
+                        if (jqXHR && jqXHR.status === 403) {
+                            const template = _('Insufficient permission: %(permission)s');
+                            window.showToast(template.replace('%(permission)s', 'edit_controllers'), 'error');
+                        } else {
+                            window.showToast(_('layout_save_fail'), 'error');
+                        }
                     }
                 });
             } catch (e) {

--- a/aot/aot_flask/templates/pages/dashboard.html
+++ b/aot/aot_flask/templates/pages/dashboard.html
@@ -187,8 +187,9 @@
   <script>
     window.AOT_GRID_CELL_HEIGHT = {{misc.grid_cell_height}};
     window.AOT_DASHBOARD_LOCKED = {{ 'true' if this_dashboard.locked else 'false' }};
+    window.AOT_CAN_EDIT_CONTROLLERS = {{ 'true' if can_edit_controllers else 'false' }};
   </script>
-  <script src="/static/js/app/dashboard.js?v=20260725d"></script>
+  <script src="/static/js/app/dashboard.js?v=20260818a"></script>
   <script src="/static/js/app/dashboard-widget-live-preview.js?v=20260813a"></script>
 
   <script>

--- a/aot/tests/test_dashboard_permission_toast.py
+++ b/aot/tests/test_dashboard_permission_toast.py
@@ -1,0 +1,184 @@
+# coding=utf-8
+"""Regression check for the dashboard permission-denied toast.
+
+Background: a read-only viewer (no edit_controllers) previously got the
+GridStack autosave listener bound on any unlocked dashboard regardless of
+their own permission (dashboard.js gated only on the dashboard's `locked`
+column). A passive page load / window resize could fire an unauthorized
+POST to /save_dashboard_layout; the server flashed a permission-denied
+message and redirected, but since the call was AJAX the browser silently
+followed the redirect and the flash sat queued in the session -- it only
+surfaced later, on some unrelated next page load, as a global toast with
+no apparent trigger.
+
+This exercises the actual Flask routes (not just the permission-check
+function in isolation) through create_app()'s real WSGI test client, using
+the isolated sqlite DB conftest.py already sets up for the test session.
+"""
+import os
+import sys
+import unittest
+
+sys.path.append(
+    os.path.abspath(os.path.join(os.path.realpath(__file__), '../../..')))
+
+os.environ.setdefault('ALEMBIC_RUNNING', '1')
+
+
+class DashboardPermissionToastFixture(unittest.TestCase):
+
+    def setUp(self):
+        from aot.aot_flask.app import create_app
+        from aot.aot_flask.extensions import db
+        from aot.databases.models import Role, User, Dashboard, Misc
+
+        self.app = create_app()
+        self.app.config['TESTING'] = True
+        self.app.config['WTF_CSRF_ENABLED'] = False
+        self.app_context = self.app.app_context()
+        self.app_context.push()
+
+        # Misc is a required singleton read on every page render.
+        if not Misc.query.first():
+            misc = Misc()
+            db.session.add(misc)
+            db.session.commit()
+
+        viewer_role = Role.query.filter(Role.name == 'ToastTestViewer').first()
+        if not viewer_role:
+            viewer_role = Role()
+            viewer_role.name = 'ToastTestViewer'
+            viewer_role.edit_controllers = False
+            viewer_role.view_settings = True
+            db.session.add(viewer_role)
+            db.session.commit()
+
+        editor_role = Role.query.filter(Role.name == 'ToastTestEditor').first()
+        if not editor_role:
+            editor_role = Role()
+            editor_role.name = 'ToastTestEditor'
+            editor_role.edit_controllers = True
+            editor_role.view_settings = True
+            db.session.add(editor_role)
+            db.session.commit()
+
+        self.viewer = User.query.filter(User.name == 'toast_test_viewer').first()
+        if not self.viewer:
+            self.viewer = User()
+            self.viewer.name = 'toast_test_viewer'
+            self.viewer.email = 'viewer@example.com'
+            self.viewer.is_enabled = True
+            self.viewer.is_approved = True
+            self.viewer.role_id = viewer_role.id
+            self.viewer.set_password('correct horse battery staple')
+            db.session.add(self.viewer)
+            db.session.commit()
+
+        self.editor = User.query.filter(User.name == 'toast_test_editor').first()
+        if not self.editor:
+            self.editor = User()
+            self.editor.name = 'toast_test_editor'
+            self.editor.email = 'editor@example.com'
+            self.editor.is_enabled = True
+            self.editor.is_approved = True
+            self.editor.role_id = editor_role.id
+            self.editor.set_password('correct horse battery staple')
+            db.session.add(self.editor)
+            db.session.commit()
+
+        self.dashboard = Dashboard.query.filter(Dashboard.name == 'Toast Test Dashboard').first()
+        if not self.dashboard:
+            self.dashboard = Dashboard()
+            self.dashboard.name = 'Toast Test Dashboard'
+            self.dashboard.locked = False
+            db.session.add(self.dashboard)
+            db.session.commit()
+
+        self.dashboard_id = self.dashboard.unique_id
+        self.client = self.app.test_client()
+
+    def tearDown(self):
+        self.app_context.pop()
+
+    def _login(self, user):
+        with self.client.session_transaction() as sess:
+            sess['_user_id'] = user.get_id()
+            sess['_fresh'] = True
+
+    def _flashed_messages_left(self):
+        """Peek at whatever is still queued in the session's flash store."""
+        with self.client.session_transaction() as sess:
+            return list(sess.get('_flashes', []))
+
+
+class TestSaveDashboardLayoutPermission(DashboardPermissionToastFixture):
+    """The endpoint the autosave listener actually calls."""
+
+    def test_viewer_gets_403_json_not_a_redirect(self):
+        self._login(self.viewer)
+        resp = self.client.post(
+            '/save_dashboard_layout',
+            data='[]',
+            content_type='application/json; charset=utf-8')
+        # Old behavior: 302 redirect (the browser follows it silently for an
+        # AJAX call, so the failure was invisible at the point of the request).
+        self.assertEqual(resp.status_code, 403)
+        self.assertEqual(resp.get_json(), {'status': 'forbidden'})
+
+    def test_viewer_denial_leaves_no_stale_flash(self):
+        self._login(self.viewer)
+        self.client.post(
+            '/save_dashboard_layout',
+            data='[]',
+            content_type='application/json; charset=utf-8')
+        # This is the actual bug: a queued flash surfaces as a toast on some
+        # later, unrelated page load. Confirm nothing was queued.
+        self.assertEqual(self._flashed_messages_left(), [])
+
+    def test_editor_can_save(self):
+        self._login(self.editor)
+        resp = self.client.post(
+            '/save_dashboard_layout',
+            data='[]',
+            content_type='application/json; charset=utf-8')
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.get_data(as_text=True), 'success')
+
+
+class TestDashboardPageReflectsPermission(DashboardPermissionToastFixture):
+    """The page render must tell the client whether it may autosave."""
+
+    def test_viewer_sees_can_edit_false_and_no_stray_toast(self):
+        self._login(self.viewer)
+        resp = self.client.get('/dashboard/{}'.format(self.dashboard_id))
+        self.assertEqual(resp.status_code, 200)
+        html = resp.get_data(as_text=True)
+        self.assertIn('window.AOT_CAN_EDIT_CONTROLLERS = false;', html)
+        # No queued permission-denied toast should be present on a bare page load.
+        self.assertNotIn('Insufficient permission', html)
+        self.assertNotIn('showToast(', html.split('get_flashed_messages')[-1][:400]
+                          if 'get_flashed_messages' not in html else '')
+
+    def test_editor_sees_can_edit_true(self):
+        self._login(self.editor)
+        resp = self.client.get('/dashboard/{}'.format(self.dashboard_id))
+        self.assertEqual(resp.status_code, 200)
+        html = resp.get_data(as_text=True)
+        self.assertIn('window.AOT_CAN_EDIT_CONTROLLERS = true;', html)
+
+    def test_viewer_page_load_after_denied_save_has_no_leftover_toast(self):
+        """End-to-end reproduction of the reported bug: a denied autosave
+        must not surface as a toast on the *next*, unrelated page load."""
+        self._login(self.viewer)
+        self.client.post(
+            '/save_dashboard_layout',
+            data='[]',
+            content_type='application/json; charset=utf-8')
+        resp = self.client.get('/dashboard/{}'.format(self.dashboard_id))
+        html = resp.get_data(as_text=True)
+        self.assertNotIn('Insufficient permission', html)
+        self.assertNotIn('권한이 없습니다', html)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

- 권한이 낮은(edit_controllers 없는) 사용자가 잠기지 않은(unlocked) 대시보드를 열면, `dashboard.js`의 `enableEditing()`이 대시보드의 `locked` 여부만 보고 무조건 grid `change` 이벤트에 자동저장 리스너를 붙였습니다. 페이지 로드 시 초기 레이아웃 동기화(`syncLayout`)나 창 크기 변경만으로도 이 리스너가 발화해 `/save_dashboard_layout`에 권한 없는 AJAX POST가 나갔습니다.
- 서버는 이 요청을 `flash()`(비침묵)로 세션에 쌓고 리다이렉트했는데, AJAX 요청이라 그 순간엔 화면에 아무것도 표시되지 않고, 사용자가 **다음에 아무 페이지나** 새로고침할 때 서버가 세션에 쌓아둔 메시지를 꺼내 전역 토스트(`window.showToast`, `layout.html`에 정의된 toastr 기반 앱 전체 공용 토스트)로 "권한이 없습니다: edit_controllers"를 띄웠습니다. 즉, 사용자가 아무 편집 행위도 하지 않았는데도 뜬금없이 오류 토스트가 나타나는 문제였습니다.
- `save_dashboard_order`, `preview_widget_options`도 동일한 패턴(AJAX 엔드포인트인데 비침묵 `flash()` 사용)을 갖고 있어 같이 수정했습니다.

## Changes

- **`dashboard.js` / `dashboard.html`**: 서버에서 뷰어의 실제 `edit_controllers` 권한을 `window.AOT_CAN_EDIT_CONTROLLERS`로 내려주고, 이 값이 있을 때만 `enableEditing()`(드래그/리사이즈 + 자동저장 리스너)을 활성화하도록 변경. 편집 권한이 없는 사용자는 애초에 자동저장 요청 자체가 나가지 않습니다.
- **`routes_dashboard.py`**:
  - `save_dashboard_layout`, `save_dashboard_order`, `preview_widget_options`의 권한 체크를 `silent=True`로 변경 — AJAX 전용 엔드포인트이므로 `flash()`로 쌓아봐야 관계없는 다음 페이지 로드에서만 노출되기 때문입니다.
  - `save_dashboard_layout`은 실패 시 리다이렉트 대신 `403 JSON`을 반환하도록 변경(다른 자매 엔드포인트들과 동일한 패턴).
  - 대시보드 렌더 컨텍스트에 `can_edit_controllers` 플래그 추가.
- **자동저장 실패 시 즉시 토스트 표시**: 세션 도중 권한이 회수되는 등 실제 편집 시도(드래그/리사이즈)가 서버에서 거부되는 경우엔, 그 시점에 바로(트리거된 시점에만) 동일한 전역 토스트로 안내하도록 `dashboard.js`의 ajax `error` 핸들러를 보강했습니다. 서버가 flash에 사용하는 것과 동일한 번역 카탈로그 문자열(`"Insufficient permission: %(permission)s"`)을 재사용해 문구를 일치시켰습니다.

## Test plan

- [x] `python3 -m py_compile aot/aot_flask/routes_dashboard.py` — 문법 확인
- [x] `node --check aot/aot_flask/static/js/app/dashboard.js` — 문법 확인
- [x] 실제 환경에서 edit_controllers 권한이 없는 계정으로 잠기지 않은 대시보드 접속 시 토스트가 뜨지 않는지 확인
- [x] 권한 있는 계정으로 위젯 드래그/리사이즈 시 정상적으로 자동저장되는지 확인

---
_Generated by [Claude Code](https://claude.ai/code/session_01WQHnkuxMfYbxZDBnr9uEET)_